### PR TITLE
fix algorithm tuple typo and numpy normed kwarg

### DIFF
--- a/realtime_decoder/decoder_process.py
+++ b/realtime_decoder/decoder_process.py
@@ -518,7 +518,7 @@ class DecoderManager(base.BinaryRecordBase, base.MessageHandler):
         config = self._config
         rank = self.rank
 
-        if config['algorithm'] in ('clusterless_decoder, clusterless_classifier'):
+        if config['algorithm'] in ('clusterless_decoder', 'clusterless_classifier'):
             self._decoder = ClusterlessDecoder(
                 rank, config,
                 position.PositionBinStruct(

--- a/realtime_decoder/encoder_process.py
+++ b/realtime_decoder/encoder_process.py
@@ -229,10 +229,14 @@ class Encoder(base.LoggingClass):
         # print("")
         # print(weights)
 
+        # `density=` (formerly `normed=`) intentionally omitted: we want the
+        # raw weighted sum per bin, which is the default behavior. `normed=`
+        # was removed in NumPy 1.24, which broke this call on any modern
+        # install.
         hist, hist_edges = np.histogram(
             a=positions,
             bins=self._pos_bin_struct.pos_bin_edges,
-            weights=weights, normed=False
+            weights=weights,
         )
 
         hist += 0.0000001


### PR DESCRIPTION
two small correctness fixes I noticed reading through the decoder.

1. `_init_decoder`'s algorithm guard was
   ```
   if config['algorithm'] in ('clusterless_decoder, clusterless_classifier'):
   ```
   that is a one-element tuple containing a single comma-joined string, not two strings. `clusterless_classifier` could never match this guard.

2. `Encoder.get_joint_prob` calls `np.histogram(..., normed=False)`. the `normed` kwarg was removed in numpy 1.24 so this raises on any modern install. dropped the kwarg, default behavior already matches `normed=False` (raw weighted sum per bin).

happy to split into two PRs if preferred but they're both pretty mechanical and one diff felt easier to review.